### PR TITLE
perf(website): hand the sidebar only the fields it renders

### DIFF
--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -117,6 +117,14 @@ async function getEslintRules(): Promise<EslintRule[]> {
 export default async function EslintDocsPage() {
   const rules = await getEslintRules()
 
+  // The sidebar is a client component, so its props ship inside the HTML.
+  // Hand it only what it renders instead of every rule's markdown body.
+  const sidebarRules = rules.map(({ id, ruleName, pluginName }) => ({
+    id,
+    ruleName,
+    pluginName,
+  }))
+
   if (!rules.length) {
     return (
       <div className="flex items-center justify-center min-h-screen p-4">
@@ -138,7 +146,7 @@ export default async function EslintDocsPage() {
   return (
     <div className="relative">
       <div className="lg:flex">
-        <RulesSidebar rules={rules} />
+        <RulesSidebar rules={sidebarRules} />
         <main className="flex-1 min-w-0 p-4 sm:p-6 lg:p-10 space-y-8 min-h-screen">
           <div className="max-w-4xl mx-auto">
             {/* Hero Section */}

--- a/website/components/rules-sidebar.tsx
+++ b/website/components/rules-sidebar.tsx
@@ -13,8 +13,15 @@ import {
 } from '@/components/ui/sheet'
 import { Download, Settings, FileText, Menu, Search, X } from 'lucide-react'
 
+/**
+ * The three fields the sidebar reads. Everything passed here is serialised into
+ * the HTML for hydration, so the full {@link EslintRule} (with its markdown
+ * body) must never cross this boundary.
+ */
+export type SidebarRule = Pick<EslintRule, 'id' | 'ruleName' | 'pluginName'>
+
 interface RulesSidebarProps {
-  rules: EslintRule[]
+  rules: SidebarRule[]
 }
 
 export function RulesSidebar({ rules }: RulesSidebarProps) {
@@ -64,7 +71,7 @@ export function RulesSidebar({ rules }: RulesSidebarProps) {
       acc[group].push(rule)
       return acc
     },
-    {} as Record<string, EslintRule[]>,
+    {} as Record<string, SidebarRule[]>,
   )
 
   const sidebarContent = (


### PR DESCRIPTION
## Why

`RulesSidebar` is a client component, so whatever it receives as props is serialised into the prerendered HTML for hydration. It was handed the full `EslintRule[]`, markdown bodies included, although it only reads `id`, `ruleName`, and `pluginName`. Every rule's raw markdown therefore shipped twice: once rendered inside the cards, once again as a JSON string in the RSC payload.

## What

- `app/page.tsx` maps the rules to `{ id, ruleName, pluginName }` before passing them to the sidebar.
- `components/rules-sidebar.tsx` types its prop as `SidebarRule = Pick<EslintRule, 'id' | 'ruleName' | 'pluginName'>`, so the markdown body cannot cross the server/client boundary again.

No rendered output changes.

## Measurement

Prerendered `.next/server/app/index.html` from `next build`, 45 rules:

| | raw | gzip |
| --- | ---: | ---: |
| main (94533bf) | 2,868,029 B | 278,157 B |
| this branch | 2,640,329 B | 223,736 B |
| delta | -227,700 B (-7.9%) | -54,421 B (-19.6%) |

The rest of the page weight is the rendered cards themselves plus their RSC copy, which this change does not touch.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm build` in `website/` pass.
- Playwright: 90 passed, 7 failed. Of the failures, the heading-anchor count was caused by the new browser-security docs and is fixed on main in 94533bf. The four nav-hover failures on Firefox and WebKit also fail on main before today's commits (0d77071): those browsers report hover colours as `oklab(...)` while the tests expect `rgba(...)` / `lab(...)`, and one assertion catches the colour mid-transition. Unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced the amount of rule data loaded by the rules sidebar, improving efficiency while preserving rule cards, statistics, and sidebar functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->